### PR TITLE
Make private_attr warning-free

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ require 'rake/testtask'
 Rake::TestTask.new do |t|
   t.name = 'spec'
   t.pattern = 'spec/**/*_spec.rb'
+  t.warning = true
 end
 
 task default: :spec

--- a/lib/private_attr.rb
+++ b/lib/private_attr.rb
@@ -2,32 +2,32 @@ require "private_attr/version"
 
 module PrivateAttr
   def private_attr_accessor *attr
-    private_attr_reader *attr
-    private_attr_writer *attr
+    private_attr_reader(*attr)
+    private_attr_writer(*attr)
   end
 
   def private_attr_reader *attr
-    attr_reader *attr
-    private *attr
+    attr_reader(*attr)
+    private(*attr)
   end
 
   def private_attr_writer *attr
-    attr_writer *attr
-    private *attr.map { |a| "#{a}=" }
+    attr_writer(*attr)
+    private(*attr.map { |a| "#{a}=" })
   end
 
   def protected_attr_accessor *attr
-    protected_attr_reader *attr
-    protected_attr_writer *attr
+    protected_attr_reader(*attr)
+    protected_attr_writer(*attr)
   end
 
   def protected_attr_reader *attr
-    attr_reader *attr
-    protected *attr
+    attr_reader(*attr)
+    protected(*attr)
   end
 
   def protected_attr_writer *attr
-    attr_writer *attr
-    protected *attr.map { |a| "#{a}=" }
+    attr_writer(*attr)
+    protected(*attr.map { |a| "#{a}=" })
   end
 end


### PR DESCRIPTION
This makes the gem warning-free and makes sure warnings are shown when running the `spec` Rake task.

Rationale: Turning warnings on helps developing Ruby projects, as it catches many subtle issues (e.g., using unitialised-because-they’re-misspelt instance variables). Unfortunately, for this to work all the dependencies must either also be warning-free or their code needs to be loaded with warnings turned off. The second option is cumbersome, so the first option is preferred.
