### PR TITLE
Make minitest and rake development dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,2 @@
 source 'https://rubygems.org'
-
-# Specify your gem's dependencies in private_attr.gemspec
 gemspec
-gem 'rake'

--- a/private_attr.gemspec
+++ b/private_attr.gemspec
@@ -17,4 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
+
+  gem.add_development_dependency 'minitest', '~> 5.0'
+  gem.add_development_dependency 'rake',     '~> 10.0'
 end


### PR DESCRIPTION
This makes `minitest`and `rake`development dependencies, which makes `rake` work properly on Ruby 2.2 (and/or solves `rubygems-bundler` compatibility issue).
