### PR TITLE
Turn all methods into module functions

### DIFF
--- a/lib/private_attr.rb
+++ b/lib/private_attr.rb
@@ -1,6 +1,8 @@
 require "private_attr/version"
 
 module PrivateAttr
+  module_function
+
   def private_attr_accessor *attr
     private_attr_reader(*attr)
     private_attr_writer(*attr)

--- a/spec/private_attr_spec.rb
+++ b/spec/private_attr_spec.rb
@@ -242,4 +242,10 @@ describe PrivateAttr do
       other.instance_variable_get('@writer').must_equal value
     end
   end
+
+  describe 'method visibility' do
+    it 'extending classes does not increase their public APIs' do
+      PrivateDummy.public_methods.wont_include :private_attr_accessor
+    end
+  end
 end


### PR DESCRIPTION
This makes all the additional methods into module functions, which makes them private. I believe it’s better not to extend the classes’ public APIs unnecessarily.
