### PR TITLE
Add private_attr/everywhere

### DIFF
--- a/lib/private_attr/everywhere.rb
+++ b/lib/private_attr/everywhere.rb
@@ -1,3 +1,4 @@
 require_relative '../private_attr'
 
-Module.include PrivateAttr
+# Module.include is private in Ruby < 2.1
+Module.__send__ :include, PrivateAttr

--- a/lib/private_attr/everywhere.rb
+++ b/lib/private_attr/everywhere.rb
@@ -1,0 +1,3 @@
+require_relative '../private_attr'
+
+Module.include PrivateAttr

--- a/spec/private_attr/everywhere_spec.rb
+++ b/spec/private_attr/everywhere_spec.rb
@@ -1,0 +1,15 @@
+require 'minitest/autorun'
+
+describe 'private_attr/everywhere' do
+  it 'requiring only private_attr keeps Classes and Modules intact' do
+    require 'private_attr'
+    -> { class  Cla; private_attr_reader :priv; end }.must_raise NoMethodError
+    -> { module Mod; private_attr_reader :priv; end }.must_raise NoMethodError
+  end
+
+  it 'requiring private_attr/everywhere adds it to all Classes and Modules' do
+    require 'private_attr/everywhere'
+    class  Cla; private_attr_reader :priv; end
+    module Mod; private_attr_reader :priv; end
+  end
+end

--- a/spec/private_attr/everywhere_spec.rb
+++ b/spec/private_attr/everywhere_spec.rb
@@ -1,6 +1,11 @@
 require 'minitest/autorun'
 
 describe 'private_attr/everywhere' do
+  # these particular tests must be ran in order
+  def self.test_order
+    :alpha
+  end
+
   it 'requiring only private_attr keeps Classes and Modules intact' do
     require 'private_attr'
     -> { class  Cla; private_attr_reader :priv; end }.must_raise NoMethodError

--- a/spec/private_attr/everywhere_spec.rb
+++ b/spec/private_attr/everywhere_spec.rb
@@ -8,13 +8,13 @@ describe 'private_attr/everywhere' do
 
   it 'requiring only private_attr keeps Classes and Modules intact' do
     require 'private_attr'
-    -> { class  Cla; private_attr_reader :priv; end }.must_raise NoMethodError
-    -> { module Mod; private_attr_reader :priv; end }.must_raise NoMethodError
+    Class.new.private_methods.wont_include :private_attr_reader
+    Module.new.private_methods.wont_include :private_attr_reader
   end
 
   it 'requiring private_attr/everywhere adds it to all Classes and Modules' do
     require 'private_attr/everywhere'
-    class  Cla; private_attr_reader :priv; end
-    module Mod; private_attr_reader :priv; end
+    Class.new.private_methods.must_include :private_attr_reader
+    Module.new.private_methods.must_include :private_attr_reader
   end
 end


### PR DESCRIPTION
This adds the ability to `require 'private_attr/everywhere'`, which makes `PrivateAttr`’s methods implicitly available in every `Class` and `Module`.

(`require 'private_attr'` works as before, allowing for a more fine-grained application of `PrivateAttr`.)
