### PR TITLE
README: add info on warning and private_attr/everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ class Bar
 end
 ```
 
+If you don’t want to extend all of your modules and classes
+separately you can also `require 'private_attr/everywhere'`
+and the methods available everywhere.
+
 ## Contributing
 
 1. Fork it

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ class Foo
 end
 ```
 
-But, I really like to declare my attribute readers and writers near the
-top of my classes, which means I sometimes use something like:
+Unfortunately, this makes Ruby show a ‘private attribute?’ warning.
+Also, I really like to declare my attribute readers and writers near
+the top of my classes, which means I sometimes use something like:
 
 ```ruby
 class Bar


### PR DESCRIPTION
This adds information that the gem solves the ‘private attribute?’ warning on `attr_*` methods called after the `private` keword and documents `private_attr/everywhere`.

It’d be ace if you could roll 1.1.0 after this is merged (I think that’s the proper semver bump, but I’m ok with a 1.0.1 if you prefer) – I’d love to drop the explicit extends from my code. :sparkles: 
